### PR TITLE
Fixed issue with Model events in traits

### DIFF
--- a/src/liteframe/Database/Model.php
+++ b/src/liteframe/Database/Model.php
@@ -149,7 +149,8 @@ class Model extends SimpleModel
     {
         $traits = class_uses($this);
         foreach ($traits as $trait) {
-            $name = basename($trait);
+            $reflect = new \ReflectionClass($trait);
+            $name = $reflect->getShortName();
             $method = "boot{$name}";
             if (method_exists($this, $method)) {
                 $this->$method();


### PR DESCRIPTION
Reflection is a better way to getting the name of trait without it's namespace contrary to `basename()`